### PR TITLE
Further cleaning up raw football-data-co-uk csv files

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -18,6 +18,7 @@ resource "aws_lambda_function" "clean_football_data_co_uk" {
     command = ["football_data_co_uk.clean_footballdata_handler"]
   }
   role    = aws_iam_role.lambda_ex.arn
+  timeout = "900"
 }
 
 # Pandas-based util that appended all partition csvs into single dataframe, which resolves column alignment issues


### PR DESCRIPTION
* enforce same columns to be in the 'clean' versions

* fix 23/24 date formatting issue for English matches

* more robust handling of simulatenous encoding/delimiter issues that can occur

* Fix referee issue in 01/02 season where commas were present for some matches