### PR TITLE
Fix inconsistent data type for home_goals column for MLS xg results

### DIFF
--- a/football_pipeline/expected_goals/fb_ref.py
+++ b/football_pipeline/expected_goals/fb_ref.py
@@ -285,7 +285,7 @@ def scrape_team_lineups():
     for comp_no, league_name in COMPETITION_NUMBER_LEAGUE_MAP.items():
         competition_season_links = [
             (_generate_scores_url(comp_no, year, league_name), league_name, create_season_code(league_name, year))
-            for year in range(2023, 2023 - 10, -1)
+            for year in range(2024, 2013, -1)
         ]
 
         print(f"League: {league_name}")
@@ -597,6 +597,11 @@ def standardise_current_xg_results_files_handler(event, context):
 
     df['time'] = df['time'].fillna('missing')
     df['venue'] = df['venue'].fillna('missing')
+
+    # clean penalty shootout affected scorelines (from MLS)
+    pattern = r'\([^)]*\)'
+    df['away_goals'] = df['away_goals'].apply(lambda x: int(re.sub(pattern, '', x).strip()))
+    df['home_goals'] = df['home_goals'].apply(lambda x: int(re.sub(pattern, '', x).strip()))
 
     output_columns = expected_columns
     output_buffer = io.BytesIO()

--- a/football_pipeline/script/standardise_current_xg_results_files.py
+++ b/football_pipeline/script/standardise_current_xg_results_files.py
@@ -1,3 +1,8 @@
+"""
+Script to manually retrigger the lambda cleaning
+function on the football-xg-results raw s3 bucket.
+"""
+
 import json
 import os
 
@@ -7,8 +12,8 @@ import requests
 s3 = boto3.client('s3')
 lambda_client = boto3.client('lambda')
 
-bucket = 'football-data-co-uk-raw'
-lambda_function_name = 'clean_football_data_co_uk'
+bucket = 'football-xg-results'
+lambda_function_name = 'standardise-raw-xg-csvs'
 
 paginator = s3.get_paginator('list_objects_v2')
 pages = paginator.paginate(Bucket=bucket)


### PR DESCRIPTION
* While reading data from football_xg_results_clean, a 'HIVE_BAD_DATA home_goals type binary in parquet file is incompatible with type defined in table schema' exception was encountered. Upon inspection, it was a result of a handful of games in Major League Soccer (MLS) having penalty shootout scorelines alongside the regular FT score, e.g  (3) 1-1 (2). Cleaning these at source to make sure that only the FT goal quantity is extracted, keeping it consistent with the INT column type.

* Add utility script to rerun the xg results cleaning lambda across the raw xg results s3 bucket.