### PR TITLE
Add FBref goals logs as a data source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,13 @@ notebooks/.ipynb_checkpoints/**
 *.xlsx
 *.tfstate
 *.backup
+*.gitkeep
 
 .DS_Store
 .idea/
-
+*.swp
+*.vscode
+.swp
 
 /lambda_payloads/
 /.ipynb_checkpoints/

--- a/football_pipeline/s3_utils.py
+++ b/football_pipeline/s3_utils.py
@@ -24,7 +24,7 @@ def upload_df_to_s3(bucket_name: str, file_key: str, df: pd.DataFrame):
 
 
 def get_scraped_urls(
-    bucket_name="football_pipeline-misc", file_key="scraped_links.txt"
+    bucket_name="football-misc", file_key="scraped_links.txt"
 ) -> Set:
     """ """
     s3 = boto3.client("s3")

--- a/requirements_simple.txt
+++ b/requirements_simple.txt
@@ -109,3 +109,4 @@ webencodings==0.5.1
 websocket-client==1.6.1
 widgetsnbextension==4.0.8
 zipp==3.16.0
+html5lib==1.1

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -46,6 +46,18 @@ resource "aws_lambda_function" "standardise-raw-xg-csvs" {
   timeout = 900
 }
 
+# Lambda for extracting and loading the goal logs for every team in the current season
+resource "aws_lambda_function" "extract-and-load-current-season-goal-logs" {
+  function_name = "extract-and-load-current-season-goal-logs"
+  image_uri     = "${aws_ecr_repository.football_repository.repository_url}:aws_ingestion_lambda_tasks"
+  role          = aws_iam_role.lambda_ex.arn
+  package_type  = "Image"
+  image_config {
+    command = ["fb_ref.extract_and_load_current_season_goal_log_handler"]
+  }
+  timeout = 900
+}
+
 # Load the lineups objects from the team lineups queue
 resource "aws_lambda_function" "team_lineups_loader" {
   depends_on    = [aws_iam_role.team-lineups-consumer-role]

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -9,8 +9,19 @@ resource "aws_sqs_queue" "team-lineups-queue" {
   })
 }
 
+resource "aws_sqs_queue" "team-lineups-queue-new" {
+  name                       = "team-lineups-queue-new"
+  fifo_queue                 = false
+  delay_seconds              = 0
+  visibility_timeout_seconds = 300
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.team-lineups-dead-letter-queue.arn
+    maxReceiveCount     = 4
+  })
+}
+
 resource "aws_lambda_event_source_mapping" "sqs_event_source" {
-  event_source_arn = aws_sqs_queue.team-lineups-queue.arn
+  event_source_arn = aws_sqs_queue.team-lineups-queue-new.arn
   function_name    = aws_lambda_function.team_lineups_loader.function_name
   enabled          = true
   batch_size       = 10


### PR DESCRIPTION
* Add crawler class that handles the scraping and loading of goal log data for every team for a given league.

* Add lambda function that will perform daily batch updates of goal log data for current season (Premier league for now but should be trivial to add more leagues in future)

* Add Terraform resources